### PR TITLE
automation: drop unsupported distributions

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,6 @@
 ---
 arch: x86_64
-distro: [el7, el8, fc29, fc30, fcraw]
+distro: [el7, el8, fcraw]
 release_branches:
   master:
     - ovirt-master


### PR DESCRIPTION
- fc30 gone EOL on 2020-05-26
- fc29 gone EOL on 2019-11-26